### PR TITLE
Fix: migrate to urlgrey v2

### DIFF
--- a/lib/decodeUri.js
+++ b/lib/decodeUri.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const urlgrey = require('urlgrey')
+const urlgrey = require('./urlgrey')
 const { getEnv } = require('./utils')
 
 module.exports = (envVarName, defaultUri) => urlgrey(getEnv(envVarName, defaultUri))

--- a/lib/unpackApiKeysConfig.js
+++ b/lib/unpackApiKeysConfig.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const assert = require('assert')
-const urlgrey = require('urlgrey')
+const urlgrey = require('./urlgrey')
 const { decodeArray } = require('./utils')
 
 module.exports = (envVarName, defaultUri) => {

--- a/lib/unpackKOPPSConfig.js
+++ b/lib/unpackKOPPSConfig.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const urlgrey = require('urlgrey')
+const urlgrey = require('./urlgrey')
 const { getEnv, typeConversion } = require('./utils')
 
 module.exports = (envVarName, defaultUri, options) => {

--- a/lib/unpackLDAPConfig.js
+++ b/lib/unpackLDAPConfig.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const urlgrey = require('urlgrey')
+const urlgrey = require('./urlgrey')
 const { getEnv, typeConversion } = require('./utils')
 
 const ldapDefaults = {

--- a/lib/unpackMongodbConfig.js
+++ b/lib/unpackMongodbConfig.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const urlgrey = require('urlgrey')
+const urlgrey = require('./urlgrey')
 const { getEnv, typeConversion } = require('./utils')
 
 module.exports = (envVarName, defaultUri, options) => {
@@ -14,8 +14,8 @@ module.exports = (envVarName, defaultUri, options) => {
   const outp = {
     username: envObj.username(),
     password: envObj.password(),
-    host: envObj._parsed.host,
-    db: envObj._parsed.pathname && envObj._parsed.pathname.replace(/\//, ''),
+    host: envObj.host(),
+    db: envObj.path() && envObj.path() !== '/' ? envObj.path().replace(/^\//, '') : null,
     uri,
     authDatabase: '',
     ssl: false

--- a/lib/unpackNodeApiConfig.js
+++ b/lib/unpackNodeApiConfig.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const urlgrey = require('urlgrey')
+const urlgrey = require('./urlgrey')
 const { getEnv, typeConversion } = require('./utils')
 
 module.exports = (envVarName, defaultUri, options) => {

--- a/lib/unpackRedisConfig.js
+++ b/lib/unpackRedisConfig.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const urlgrey = require('urlgrey')
+const urlgrey = require('./urlgrey')
 const qs = require('qs')
 const { getEnv, typeConversion } = require('./utils')
 

--- a/lib/unpackSMTPConfig.js
+++ b/lib/unpackSMTPConfig.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const urlgrey = require('urlgrey')
+const urlgrey = require('./urlgrey')
 const { getEnv, typeConversion } = require('./utils')
 
 module.exports = (envVarName, defaultUri, options) => {

--- a/lib/unpackSQLServerConfig.js
+++ b/lib/unpackSQLServerConfig.js
@@ -6,7 +6,7 @@
   Example: file://path/to/your/sqlite.db
 */
 
-const urlgrey = require('urlgrey')
+const urlgrey = require('./urlgrey')
 const { getEnv } = require('./utils')
 
 const _isCorrectURI = (envObj) => /^mssql/.test(envObj.protocol())

--- a/lib/unpackSequelizeConfig.js
+++ b/lib/unpackSequelizeConfig.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const urlgrey = require('urlgrey')
+const urlgrey = require('./urlgrey')
 const { getEnv } = require('./utils')
 const unpackSqliteConfig = require('./unpackSqliteConfig')
 const unpackSQLServerConfig = require('./unpackSQLServerConfig')

--- a/lib/unpackSqliteConfig.js
+++ b/lib/unpackSqliteConfig.js
@@ -6,7 +6,7 @@
   Example: file://path/to/your/sqlite.db
 */
 
-const urlgrey = require('urlgrey')
+const urlgrey = require('./urlgrey')
 const { getEnv } = require('./utils')
 
 const _isSqlliteURI = (envObj) => /^sqlite/.test(envObj.protocol())

--- a/lib/urlgrey.js
+++ b/lib/urlgrey.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const qs = require('qs')
+const urlgreyImport = require('urlgrey')
+
+const parseUrl =
+  typeof urlgreyImport === 'function'
+    ? urlgreyImport
+    : urlgreyImport && typeof urlgreyImport.default === 'function'
+      ? urlgreyImport.default
+      : null
+
+if (!parseUrl) {
+  throw new TypeError('Unsupported urlgrey export shape')
+}
+
+const callGetter = (obj, getterName, legacyName) => {
+  if (typeof obj[getterName] === 'function') {
+    return obj[getterName]()
+  }
+  if (typeof obj[legacyName] === 'function') {
+    return obj[legacyName]()
+  }
+  return undefined
+}
+
+const decodeMaybe = (value) => {
+  if (typeof value !== 'string') {
+    return value
+  }
+  try {
+    return decodeURIComponent(value)
+    // eslint-disable-next-line no-unused-vars
+  } catch (err) {
+    return value
+  }
+}
+
+const normalizeInput = (url) => {
+  if (typeof url === 'string' && url.startsWith('?')) {
+    return `http://localhost/${url}`
+  }
+  return url
+}
+
+module.exports = (url) => {
+  const parsed = parseUrl(normalizeInput(url))
+  const adapted = Object.create(parsed)
+
+  adapted.protocol = () => callGetter(parsed, 'getProtocol', 'protocol')
+  adapted.hostname = () => callGetter(parsed, 'getHostname', 'hostname')
+  adapted.port = () => callGetter(parsed, 'getPort', 'port')
+  adapted.path = () => callGetter(parsed, 'getPath', 'path')
+  adapted.query = () => {
+    const queryString = adapted.queryString()
+    if (!queryString) {
+      return {}
+    }
+    return qs.parse(queryString)
+  }
+  adapted.queryString = () => callGetter(parsed, 'getQueryString', 'queryString')
+  adapted.username = () => decodeMaybe(callGetter(parsed, 'getUsername', 'username'))
+  adapted.password = () => decodeMaybe(callGetter(parsed, 'getPassword', 'password'))
+
+  adapted.host = () => {
+    const hostname = adapted.hostname()
+    const port = adapted.port()
+
+    if (!hostname) {
+      return hostname
+    }
+    if (port === null || port === undefined || port === '') {
+      return hostname
+    }
+    return `${hostname}:${port}`
+  }
+
+  return adapted
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kth-node-configuration",
-  "version": "2.2.0",
+  "version": "3.0.0-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kth-node-configuration",
-      "version": "2.2.0",
+      "version": "3.0.0-0",
       "license": "MIT",
       "dependencies": {
         "qs": "^6.15.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "qs": "^6.15.3",
-        "urlgrey": "^0.4.4"
+        "urlgrey": "^2.1.0"
       },
       "devDependencies": {
         "@kth/eslint-config-kth": "^4.1.0",
@@ -8480,9 +8480,10 @@
       }
     },
     "node_modules/urlgrey": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-      "integrity": "sha512-vfQzI+JDPBrBRw374pgWi6bFPfc+6BonRsazCj3weBIWe8moRcvfgy0lpaiGkMGnExs4Z/Dws8lp5mc9IegURw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-2.1.0.tgz",
+      "integrity": "sha512-sxDmadL2pEw+MBYVMhRxhG34HEhrToBtePQ1tSrREkxq9y/Q+fBfKYvvaKz9mlwZdgihSgkBb9JBULIr+LIdLg==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "qs": "^6.15.3",
-    "urlgrey": "^0.4.4"
+    "urlgrey": "^2.1.0"
   },
   "author": {
     "name": "KTH",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kth-node-configuration",
-  "version": "2.2.0",
+  "version": "3.0.0-0",
   "description": "Configuration module for Node.js projects",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Use intermediate `lib/urlgrey.js` for low impact migration.

Available in pre-release [kth-node-configuration v3.0.0-0](https://www.npmjs.com/package/kth-node-configuration/v/3.0.0-0)